### PR TITLE
Bugfix/measure against when open empty card

### DIFF
--- a/server/src/public/javascripts/script.js
+++ b/server/src/public/javascripts/script.js
@@ -67,6 +67,8 @@ socketio.on("result_card_list", function (result_arr) {
 
 // オープンボタンを押したとき
 document.getElementById("open").onclick = function () {
+  // 1枚もカードが選択されていなかったら何もしない
+  if (panel.childElementCount == 0) return;
   socketio.emit("open", { room, name });
 };
 //　オープン情報受信

--- a/server/src/views/entrance.ejs
+++ b/server/src/views/entrance.ejs
@@ -10,7 +10,7 @@
 
 <body>
   <header>
-    <h1 id='title'>Hajime Poker uouo</h1>
+    <h1 id='title'>Hajime Poker</h1>
   </header>
   <div class="room_button">
     Your Name ▶


### PR DESCRIPTION
## やったこと

- カードが1枚も選択されていない状態で `Open` ボタンを押した場合、サーバー側に通信を行わないようにした

## 確認ポイント

- カードを1枚も選択していない状態で `Open` ボタンを押しても、その後他の動作が正常に動くこと
- カードを選択した状態で `Open` ボタンを押すと、今まで通りの動作となること