### PR TITLE
スクロールバーを表示しないようにした

### DIFF
--- a/server/src/public/stylesheets/style.css
+++ b/server/src/public/stylesheets/style.css
@@ -213,8 +213,14 @@ input[type="text"]:focus {
   color: #dcdcdc;
   max-height: 10em;
   overflow: scroll;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 .room_info p {
   line-height: 0.5;
+}
+
+.room_info::-webkit-scrollbar{
+  display: none;
 }


### PR DESCRIPTION
### 概要
ブラウザによっては room 内のお知らせ部分が `overflow: scroll` によりスクロールバーが表示されてしまい格好悪いので、スクロールバーを出さないようにしました。

### 確認ポイント
- windows の主要ブラウザでスクロールバーが表示されないこと
  - mac safari, chrome でのみ問題ないことを確認しています